### PR TITLE
Prevent warp after user mouse movement

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -1,5 +1,6 @@
 /* appearance */
 static const int sloppyfocus               = 1;  /* focus follows mouse */
+static const int mousefollowsfocus         = 1;  /* mouse follows focus */
 static const int bypass_surface_visibility = 0;  /* 1 means idle inhibitors will disable idle tracking even if it's surface isn't visible  */
 static const unsigned int borderpx         = 1;  /* border pixel of windows */
 static const float rootcolor[]             = {0.3, 0.3, 0.3, 1.0};

--- a/dwl.c
+++ b/dwl.c
@@ -2613,9 +2613,11 @@ void
 warpcursortoclient(Client *c) {
 	struct wlr_box mg = c->mon->m;
 	struct wlr_box cg = c->geom;
+	if (!VISIBLEON(c, selmon)) return;
 	wlr_cursor_warp_absolute(cursor, NULL,
 		((double)cg.x + (double)cg.width / 2.0) / (double)mg.width,
 		((double)cg.y + (double)cg.height / 2.0) / (double)mg.height);
+	motionnotify(0);
 }
 
 Monitor *

--- a/dwl.c
+++ b/dwl.c
@@ -313,6 +313,7 @@ static void updatetitle(struct wl_listener *listener, void *data);
 static void urgent(struct wl_listener *listener, void *data);
 static void view(const Arg *arg);
 static void virtualkeyboard(struct wl_listener *listener, void *data);
+static void warpcursortoclient(Client *c);
 static Monitor *xytomon(double x, double y);
 static struct wlr_scene_node *xytonode(double x, double y, struct wlr_surface **psurface,
 		Client **pc, LayerSurface **pl, double *nx, double *ny);
@@ -1265,6 +1266,8 @@ focusclient(Client *c, int lift)
 
 	/* Activate the new client */
 	client_activate_surface(client_surface(c), 1);
+
+	if (mousefollowsfocus) warpcursortoclient(c);
 }
 
 void
@@ -2604,6 +2607,15 @@ virtualkeyboard(struct wl_listener *listener, void *data)
 {
 	struct wlr_virtual_keyboard_v1 *keyboard = data;
 	createkeyboard(&keyboard->keyboard);
+}
+
+void
+warpcursortoclient(Client *c) {
+	struct wlr_box mg = c->mon->m;
+	struct wlr_box cg = c->geom;
+	wlr_cursor_warp_absolute(cursor, NULL,
+		((double)cg.x + (double)cg.width / 2.0) / (double)mg.width,
+		((double)cg.y + (double)cg.height / 2.0) / (double)mg.height);
 }
 
 Monitor *

--- a/dwl.c
+++ b/dwl.c
@@ -2611,12 +2611,12 @@ virtualkeyboard(struct wl_listener *listener, void *data)
 
 void
 warpcursortoclient(Client *c) {
-	struct wlr_box mg = c->mon->m;
+	struct wlr_box *mg = (c->mon) ? &c->mon->m : NULL;
 	struct wlr_box cg = c->geom;
-	if (!VISIBLEON(c, selmon)) return;
+	if (!mg || !VISIBLEON(c, selmon)) return;
 	wlr_cursor_warp_absolute(cursor, NULL,
-		((double)cg.x + (double)cg.width / 2.0) / (double)mg.width,
-		((double)cg.y + (double)cg.height / 2.0) / (double)mg.height);
+		((double)cg.x + (double)cg.width / 2.0) / (double)mg->width,
+		((double)cg.y + (double)cg.height / 2.0) / (double)mg->height);
 	motionnotify(0);
 }
 

--- a/local-monitors.h
+++ b/local-monitors.h
@@ -1,0 +1,3 @@
+
+/* Laptop */
+{ "eDP-1",    0.55, 1,      1,    &layouts[0], WL_OUTPUT_TRANSFORM_NORMAL, 0, 0, 0, 0, 0, 0, 0},


### PR DESCRIPTION
Your patch is wonderful, and it has greatly improved my DWL experience!

I've run into issues with it though, because it performs the warp even if I move the mouse myself. This is rather jarring, and in a few cases, like when using steam or steamvr, this causes menus to be unusable.

My solution is to simply remember the timestamp that the user last moved the mouse themselves, and disable cursor warping within 500 msec of that action. This appears to do the trick. The warping still behaves properly when initiated from the keyboard, but doesn't interfere when triggered by a mouse movement.